### PR TITLE
Support to build Ruby 2.2.0

### DIFF
--- a/dgate.gemspec
+++ b/dgate.gemspec
@@ -24,7 +24,7 @@ Or see the docs at:
 
 POST_INSTALL_MESSAGE
 
-  spec.add_dependency 'json', '~> 1.7.4'
+  spec.add_dependency 'json', '~> 1.8.2'
   spec.add_dependency 'httpclient', '~> 2.2.5'
 
   spec.add_development_dependency "bundler", "~> 1.3"


### PR DESCRIPTION
Upgrade json version to "~> 1.8.2" to fix the following error.

```
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    /home/username/.rbenv/versions/2.2.0/bin/ruby -r ./siteconf20150129-31331-1y4ypko.rb extconf.rb
creating Makefile

make "DESTDIR=" clean

make "DESTDIR="
compiling generator.c
In file included from generator.c:1:0:
../fbuffer/fbuffer.h: In function ‘fbuffer_to_s’:
../fbuffer/fbuffer.h:175:47: error: macro "rb_str_new" requires 2 arguments, but only 1 given
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                                               ^
../fbuffer/fbuffer.h:175:20: warning: initialization makes integer from pointer without a cast [enabled by default]
     VALUE result = rb_str_new(FBUFFER_PAIR(fb));
                    ^
make: *** [generator.o] Error 1

make failed, exit code 2
```
