### PR TITLE
Updated httpclient version

### DIFF
--- a/dgate.gemspec
+++ b/dgate.gemspec
@@ -25,7 +25,7 @@ Or see the docs at:
 POST_INSTALL_MESSAGE
 
   spec.add_dependency 'json', '~> 1.8.2'
-  spec.add_dependency 'httpclient', '~> 2.2.5'
+  spec.add_dependency 'httpclient', '~> 2.8.0'
 
   spec.add_development_dependency "bundler", "~> 1.3"
   spec.add_development_dependency "rake"


### PR DESCRIPTION
Upgrade httpclient version to 2.8.0.
There are some dependency problem in 2.2.5.
I want to support 2.8.0 that is the latest version
